### PR TITLE
Add Sharpe to free crypto market data APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This catalog focuses on APIs that are practical to try for free, whether through
 | [CoinStats](https://coinstats.app/api-docs/) | Coin prices, charts, market caps, and movers | Free API plan with monthly credits and API key | `apiKey` | [Docs](https://coinstats.app/api-docs/) |
 | [CryptoCompare](https://min-api.cryptocompare.com/documentation) | Price, volume, and aggregate market feeds | Free developer plan with rate limits | `apiKey` | [Docs](https://min-api.cryptocompare.com/documentation) |
 | [Santiment](https://academy.santiment.net/sanapi/introduction/) | Market, social, on-chain, and dev metrics | Free plan exists but access is restricted | `apiKey` | [Docs](https://academy.santiment.net/sanapi/introduction/) |
+| [Sharpe](https://www.sharpe.ai/docs/free-api) | Funding, futures, options, arbitrage, narratives, and news data | Public no-key endpoints documented for lightweight use | No | [Docs](https://www.sharpe.ai/docs/free-api) |
 
 ### Exchange & Trading
 | API | What It Is Good For | Free Plan | Auth | Docs |


### PR DESCRIPTION
Summary
- Adds Sharpe to the Market Data table.
- Marks auth as No because the documented free endpoints can be called without an API key.
- Links directly to the free API docs.

Why this belongs here
The catalog focuses on crypto APIs that are practical to try for free. Sharpe provides no-key endpoints for funding, futures, options, arbitrage, narratives, and news, which makes it a fit for the Market Data section.

Verification
- npm test
- npm run validate:readme
- npm run validate:links, with the Sharpe link passing. The command still fails on existing coinlib.io and blockchair.com links outside this change.
- Searched open and closed PRs and issues for Sharpe before submitting.

Disclosure
I am affiliated with Sharpe.
